### PR TITLE
Add support for Stardew Valley 1.6.0, SMAPI 4.0.0

### DIFF
--- a/Patches/GameLocationPatches.cs
+++ b/Patches/GameLocationPatches.cs
@@ -25,7 +25,7 @@ namespace PlacementPlus.Patches
                 var tileIsPassable = __instance.isTilePassable(location, Game1.viewport);
                 var tileHasNoFurniture = __instance.GetFurnitureAt(tileLocation) == null;
 
-                __result = playerIsNotOnTile && tileIsNotOccupied && tileIsPassable && tileHasNoFurniture;
+                __result |= playerIsNotOnTile && tileIsNotOccupied && tileIsPassable && tileHasNoFurniture;
             }
             catch (Exception e) {
                 Monitor.Log($"Failed in {nameof(GameLocationPatches)}:\n{e}", LogLevel.Error);

--- a/Patches/GameLocationPatches.cs
+++ b/Patches/GameLocationPatches.cs
@@ -3,33 +3,32 @@ using HarmonyLib;
 using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewValley;
-using StardewValley.Locations;
 using xTile.Dimensions;
 
 using static PlacementPlus.ModState;
 
 namespace PlacementPlus.Patches
 {
-    [HarmonyPatch(typeof(BuildableGameLocation), nameof(BuildableGameLocation.isBuildable))]
-    internal class BuildableGameLocationPatches
+    [HarmonyPatch(typeof(GameLocation), nameof(GameLocation.isBuildable))]
+    internal class GameLocationPatches
     {
         /// <summary> Alters the requirements for where buildings can be built. </summary>
-        private static void Postfix(Vector2 tileLocation, BuildableGameLocation __instance, ref bool __result)
+        private static void Postfix(Vector2 tileLocation, GameLocation __instance, ref bool __result)
         {
             try
             {
                 var location = new Location((int)tileLocation.X, (int)tileLocation.Y);
 
                 // Define new (loosened) requirements for building placement.
-                var playerIsNotOnTile = !Game1.player.getTileLocation().Equals(tileLocation);
-                var tileIsNotOccupied = !__instance.isTileOccupiedForPlacement(tileLocation);
+                var playerIsNotOnTile = !Game1.player.Tile.Equals(tileLocation);
+                var tileIsNotOccupied = !__instance.CanItemBePlacedHere(tileLocation);
                 var tileIsPassable = __instance.isTilePassable(location, Game1.viewport);
                 var tileHasNoFurniture = __instance.GetFurnitureAt(tileLocation) == null;
 
                 __result = playerIsNotOnTile && tileIsNotOccupied && tileIsPassable && tileHasNoFurniture;
             }
             catch (Exception e) {
-                Monitor.Log($"Failed in {nameof(BuildableGameLocationPatches)}:\n{e}", LogLevel.Error);
+                Monitor.Log($"Failed in {nameof(GameLocationPatches)}:\n{e}", LogLevel.Error);
             }
         }
     }

--- a/Patches/ObjectPatches.cs
+++ b/Patches/ObjectPatches.cs
@@ -44,22 +44,22 @@ namespace PlacementPlus.Patches
                         // Otherwise we check for interactable components on buildings if the location is the farm.
                         return location is Farm farm && IsTileOnBuildingInteractable(farm, tilePos);
                     }
-                    
-                    
+
+
                     // We do not swap if:
                     //  - Both the player-held flooring and tile flooring are the same.
                     //  - The player is not holding the use tool button and the tile has an interactable object/feature
                     //      (i.e. mailbox, shipping bin, etc.) (we want their actions to still be accessible).
-                    if (IsItemTargetFlooring(__instance, flooring) || (!holdingToolButton && tileHasInteractable())) 
+                    if (IsItemTargetFlooring(__instance, flooring) || (!holdingToolButton && tileHasInteractable()))
                         return false;
 
                     
                     // We use performToolAction() drops the flooring at tile as an item and generates the respective
                     // destruction debris, destruction sound, etc. Axes can destroy all flooring.
-                    terrainFeatures[tilePos].performToolAction(new Axe(), 0, tilePos, location);
+                    terrainFeatures[tilePos].performToolAction(new Axe(), 0, tilePos);
                     terrainFeatures.Remove(tilePos);
                     
-                    terrainFeatures.Add(tilePos, new Flooring(FlooringInfoMap[__instance.ParentSheetIndex]));
+                    terrainFeatures.Add(tilePos, new Flooring(FlooringInfoMap[__instance.QualifiedItemId]));
 
                     who.reduceActiveItemByOne();
                     return true;
@@ -82,21 +82,20 @@ namespace PlacementPlus.Patches
                     
                     // We must use the correct tool to destroy the fence as if the fence has been converted to a gate,
                     // it needs to drop the gate as well as the original fence.
-                    var usePickaxe = (FenceType) fence.whichType.Value is
-                        FenceType.Stone_fence or FenceType.Iron_fence;
-                    fence.performToolAction(usePickaxe ? new Pickaxe() : new Axe(), location);
+                    var usePickaxe = fence.QualifiedItemId is FenceType.Stone_fence or FenceType.Iron_fence;
+                    fence.performToolAction(usePickaxe ? new Pickaxe() : new Axe());
                 
                     __instance.placementAction(location, x, y);
                     // Ensure that if the original fence has a torch, it is preserved.
-                    if (fence.heldObject.Value is Torch) tileObject.heldObject.Value = new Torch(tilePos, 1);
+                    if (fence.heldObject.Value is Torch) tileObject.heldObject.Value = new Torch();
 
                     who.reduceActiveItemByOne();
                     return true;
                 }
-                
-                
+
+
                 if (IsItemFlooring(__instance) && DoesTileHaveFlooring(terrainFeatures, tilePos))
-                    __result = SwapFlooring((Flooring) terrainFeatures[tilePos]);
+                    __result = SwapFlooring((Flooring)terrainFeatures[tilePos]);
                 else if (IsItemFence(__instance) && IsItemFence(tileObject))
                     __result = SwapFence(tileObject as Fence);
 

--- a/Patches/ObjectPatches.cs
+++ b/Patches/ObjectPatches.cs
@@ -65,34 +65,6 @@ namespace PlacementPlus.Patches
                     return true;
                 }
                 
-                bool SwapChest(Chest chest) 
-                {
-                    // Do not swap if the player is not holding the use tool button (we want their inventory to still be
-                    // accessible).
-                    if (!holdingToolButton) return false;
-                    
-                    
-                    var chestToPlace = new Chest(true, tilePos, __instance.ParentSheetIndex) {
-                        shakeTimer        = 100,
-                        playerChoiceColor = { Value = chest.playerChoiceColor.Value } };
-                    chestToPlace.items.Set(chest.items); // Fill the new chest with the items of the old chest.
-
-                    var isWoodenChest = chest.ParentSheetIndex == (int) ChestType.Chest;
-                    // We clear out the chest's inventory before simulating its destruction.
-                    chest.items.Clear(); chest.clearNulls();
-                    location.debris.Add(new Debris(-chest.ParentSheetIndex, new Vector2(x + 32, y + 32), who.Position));
-                    location.playSound(isWoodenChest ? "axe" : "hammer");
-                    
-                    // Spawning broken particles to simulate chest breaking.
-                    Game1.createRadialDebris(location, isWoodenChest ? 12 : 14, 64 * x, 64 * y, 4, false);
-                    location.Objects.Remove(tilePos);
-                    
-                    location.Objects.Add(tilePos, chestToPlace);
-
-                    who.reduceActiveItemByOne();
-                    return true;
-                }
-                
                 bool SwapFence(Fence fence) 
                 {
                     // We do not swap if:
@@ -125,11 +97,6 @@ namespace PlacementPlus.Patches
                 
                 if (IsItemFlooring(__instance) && DoesTileHaveFlooring(terrainFeatures, tilePos))
                     __result = SwapFlooring((Flooring) terrainFeatures[tilePos]);
-                else if (IsItemChest(__instance) && IsItemChest(tileObject))
-                    // We still skip the original logic if the chests are equal as to prevent the 'Unsuitable Location'
-                    // dialogue from appearing when trying to place a chest where a chest already exists.
-                    __result = __instance.ParentSheetIndex == tileObject.ParentSheetIndex || 
-                               SwapChest(tileObject as Chest);
                 else if (IsItemFence(__instance) && IsItemFence(tileObject))
                     __result = SwapFence(tileObject as Fence);
 

--- a/Patches/ObjectPatches.cs
+++ b/Patches/ObjectPatches.cs
@@ -61,7 +61,6 @@ namespace PlacementPlus.Patches
                     
                     terrainFeatures.Add(tilePos, new Flooring(FlooringInfoMap[__instance.QualifiedItemId]));
 
-                    who.reduceActiveItemByOne();
                     return true;
                 }
                 
@@ -89,7 +88,6 @@ namespace PlacementPlus.Patches
                     // Ensure that if the original fence has a torch, it is preserved.
                     if (fence.heldObject.Value is Torch) tileObject.heldObject.Value = new Torch();
 
-                    who.reduceActiveItemByOne();
                     return true;
                 }
 

--- a/Patches/ObjectPatches.cs
+++ b/Patches/ObjectPatches.cs
@@ -78,7 +78,9 @@ namespace PlacementPlus.Patches
                         || IsItemGate(__instance)) 
                     { return false; }
 
-                    
+                    // Before destroying the fence, check if there was a torch.
+                    var hadTorch = fence.heldObject.Value is Torch;
+
                     // We must use the correct tool to destroy the fence as if the fence has been converted to a gate,
                     // it needs to drop the gate as well as the original fence.
                     var usePickaxe = fence.QualifiedItemId is FenceType.Stone_fence or FenceType.Iron_fence;
@@ -86,7 +88,7 @@ namespace PlacementPlus.Patches
                 
                     __instance.placementAction(location, x, y);
                     // Ensure that if the original fence has a torch, it is preserved.
-                    if (fence.heldObject.Value is Torch) tileObject.heldObject.Value = new Torch();
+                    if (hadTorch) location.getObjectAt(x, y).heldObject.Value = new Torch();
 
                     return true;
                 }

--- a/Patches/ReusablePatches.cs
+++ b/Patches/ReusablePatches.cs
@@ -34,8 +34,14 @@ namespace PlacementPlus.Patches
                 .Select(m => m.GetMethod(nameof(Building.doAction)));
 
             // Combining all gathered target MethodInfo entries with some additional ones.
+
             return checkForActionEnumerable.Concat(doActionEnumerable).Concat(new [] {
-                AccessTools.Method(typeof(GameLocation), nameof(GameLocation.performAction)), 
+                AccessTools.Method(typeof(GameLocation), nameof(GameLocation.performAction), new Type[] {
+                    typeof(string), typeof(Farmer), typeof(xTile.Dimensions.Location)
+                }),
+                AccessTools.Method(typeof(GameLocation), nameof(GameLocation.performAction), new Type[] {
+                    typeof(string[]), typeof(Farmer), typeof(xTile.Dimensions.Location)
+                }),
                 AccessTools.Method(typeof(ShippingBin), nameof(ShippingBin.leftClicked)),
             });
         }

--- a/Patches/UtilityPatches.cs
+++ b/Patches/UtilityPatches.cs
@@ -36,8 +36,6 @@ namespace PlacementPlus.Patches
                     __result = tileObject != null || 
                                (location is Farm farm && (IsTileOnBuildingEdge(farm, tilePos) || 
                                                           DoesTileHaveMainMailbox(farm, tilePos)));
-                else if (IsItemChest(item))
-                    __result = IsItemChest(tileObject);
                 else if (IsItemFence(item))
                     __result = IsItemFence(tileObject);
             } catch (Exception e) {

--- a/PlacementPlus.csproj
+++ b/PlacementPlus.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <AssemblyName>PlacementPlus</AssemblyName>
         <RootNamespace>PlacementPlus</RootNamespace>
-        <Version>2.0.0-unofficial</Version>
+        <Version>2.0.1-unofficial</Version>
         <TargetFramework>net6.0</TargetFramework>
         <EnableHarmony>true</EnableHarmony>
     </PropertyGroup>

--- a/PlacementPlus.csproj
+++ b/PlacementPlus.csproj
@@ -3,7 +3,7 @@
         <AssemblyName>PlacementPlus</AssemblyName>
         <RootNamespace>PlacementPlus</RootNamespace>
         <Version>1.2.0</Version>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <EnableHarmony>true</EnableHarmony>
     </PropertyGroup>
 

--- a/PlacementPlus.csproj
+++ b/PlacementPlus.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <AssemblyName>PlacementPlus</AssemblyName>
         <RootNamespace>PlacementPlus</RootNamespace>
-        <Version>1.2.0</Version>
+        <Version>2.0.0-unofficial</Version>
         <TargetFramework>net6.0</TargetFramework>
         <EnableHarmony>true</EnableHarmony>
     </PropertyGroup>

--- a/Utility/Utility.cs
+++ b/Utility/Utility.cs
@@ -45,14 +45,6 @@ namespace PlacementPlus.Utility
             { (int) FenceType.Gate,           325 },
             { (int) FenceType.Hardwood_fence, 298 },
         };
-        
-        // enum mapping to chest types.
-        public enum ChestType { Chest, Stone_chest, }
-        // Bi-directional mapping between chest types and their respective item's ParentSheetIndex.
-        public static readonly BiDictionary<int> ChestInfoMap = new()
-        {
-            { (int) ChestType.Chest,       130 },
-            { (int) ChestType.Stone_chest, 232 },
         };
 
 
@@ -80,12 +72,6 @@ namespace PlacementPlus.Utility
         /// <summary> Returns <c>true</c> if <c>item</c> is the target flooring; otherwise, <c>false</c>. </summary>
         public static bool IsItemTargetFlooring(Item item, Flooring flooring) =>
             item.ParentSheetIndex == FlooringInfoMap[flooring.whichFloor.Value];
-        
-
-
-        /// <summary> Returns <c>true</c> if <c>item</c> is a chest; otherwise, <c>false</c>. </summary>
-        public static bool IsItemChest(Item item) =>
-            item != null && ChestInfoMap.ContainsKey(item.ParentSheetIndex);
 
 
 

--- a/Utility/Utility.cs
+++ b/Utility/Utility.cs
@@ -4,47 +4,42 @@ using StardewValley;
 using StardewValley.Buildings;
 using StardewValley.Network;
 using StardewValley.TerrainFeatures;
-
+using System.Collections.Generic;
 using Object = StardewValley.Object;
 
 namespace PlacementPlus.Utility
 {
-    public static class Utility
-    {
-        // enum mapping to flooring types--the order represented matters! 
-        public enum FlooringType 
-        { 
-            Wood_floor, Stone_floor, Weathered_floor, Crystal_floor, Straw_floor, Gravel_floor, Rustic_plank_floor, 
-            Crystal_path, Cobblestone_path, Stepping_stone_path, Brick_floor, Wood_path, Stone_walkway_floor,
-        }
-        // Bi-directional mapping between flooring types and their respective item's ParentSheetIndex.
-        public static readonly BiDictionary<int> FlooringInfoMap = new() {
-            { (int) FlooringType.Wood_floor,          328 },
-            { (int) FlooringType.Stone_floor,         329 },
-            { (int) FlooringType.Weathered_floor,     331 },
-            { (int) FlooringType.Crystal_floor,       333 },
-            { (int) FlooringType.Straw_floor,         401 },
-            { (int) FlooringType.Gravel_floor,        407 },
-            { (int) FlooringType.Rustic_plank_floor,  405 },
-            { (int) FlooringType.Crystal_path,        409 },
-            { (int) FlooringType.Cobblestone_path,    411 },
-            { (int) FlooringType.Stepping_stone_path, 415 },
-            { (int) FlooringType.Brick_floor,         293 },
-            { (int) FlooringType.Wood_path,           840 },
-            { (int) FlooringType.Stone_walkway_floor, 841 },
+    public static class Utility {
+        // Bi-directional mapping between flooring types and their respective item's qualified item id.
+        // Note that the flooring itself would instead use ItemRegistry.type_floorpaper (FL).
+        public static readonly BiDictionary<string> FlooringInfoMap = new() {
+            { Flooring.wood,                "(O)328" },
+            { Flooring.stone,               "(O)329" },
+            { Flooring.ghost,               "(O)331" },
+            { Flooring.iceTile,             "(O)333" },
+            { Flooring.straw,               "(O)401" },
+            { Flooring.gravel,              "(O)407" },
+            { Flooring.boardwalk,           "(O)405" },
+            { Flooring.colored_cobblestone, "(O)409" },
+            { Flooring.cobblestone,         "(O)411" },
+            { Flooring.steppingStone,       "(O)415" },
+            { Flooring.brick,               "(O)293" },
+            { Flooring.plankFlooring,       "(O)840" },
+            { Flooring.townFlooring,        "(O)841" },
         };
 
-        // enum mapping to fence types--the order represented matters! 
-        public enum FenceType { Wood_fence = 1, Stone_fence, Iron_fence, Gate, Hardwood_fence, }
-        // Bi-directional mapping between fence types and their respective item's ParentSheetIndex.
-        public static readonly BiDictionary<int> FenceInfoMap = new()
-        {
-            { (int) FenceType.Wood_fence,     322 },
-            { (int) FenceType.Stone_fence,    323 },
-            { (int) FenceType.Iron_fence,     324 },
-            { (int) FenceType.Gate,           325 },
-            { (int) FenceType.Hardwood_fence, 298 },
-        };
+
+
+        // Qualified IDs for fence items.
+        public static class FenceType {
+            public const string Wood_fence     = "(O)322";
+            public const string Stone_fence    = "(O)323";
+            public const string Iron_fence     = "(O)324";
+            public const string Gate           = "(O)325";
+            public const string Hardwood_fence = "(O)298";
+        }
+        public static readonly HashSet<string> FenceTypes = new() {
+            FenceType.Wood_fence, FenceType.Stone_fence, FenceType.Iron_fence, FenceType.Gate, FenceType.Hardwood_fence,
         };
 
 
@@ -62,33 +57,28 @@ namespace PlacementPlus.Utility
 
 
         /// <summary> Returns <c>true</c> if <c>item</c> is flooring; otherwise, <c>false</c>. </summary>
-        // ? Does the furniture category only cover flooring?
         public static bool IsItemFlooring(Item item) =>
-            item.Category == Object.furnitureCategory;
+            item != null && FlooringInfoMap.ContainsKey(item.QualifiedItemId);
         
 
         
-        
         /// <summary> Returns <c>true</c> if <c>item</c> is the target flooring; otherwise, <c>false</c>. </summary>
         public static bool IsItemTargetFlooring(Item item, Flooring flooring) =>
-            item.ParentSheetIndex == FlooringInfoMap[flooring.whichFloor.Value];
+            item != null && item.QualifiedItemId == FlooringInfoMap[flooring.whichFloor.Value];
 
 
 
         /// <summary> Returns <c>true</c> if <c>item</c> is a fence gate; otherwise, <c>false</c>. </summary>
         // We either cast the item as Fence and check if it's a gate (for Objects), or compare the item's
         // ParentSheetIndex with the index for gates (for Items).
-        public static bool IsItemGate(Item item)
-        {
-            return item != null && 
-                   ((item as Fence)?.isGate.Value ?? item.ParentSheetIndex == FenceInfoMap[(int)FenceType.Gate]);
-        }
+        public static bool IsItemGate(Item item) => item != null &&
+            ((item as Fence)?.isGate.Value ?? item.QualifiedItemId == FenceType.Gate);
 
 
 
         /// <summary> Returns <c>true</c> if <c>item</c> is a fence; otherwise, <c>false</c>. </summary>
         public static bool IsItemFence(Item item) =>
-            item != null && (FenceInfoMap.ContainsKey(item.ParentSheetIndex) || item is Fence);
+            item != null && (FenceTypes.Contains(item.QualifiedItemId) || item is Fence);
         
         
         
@@ -144,9 +134,9 @@ namespace PlacementPlus.Utility
             
 
             var building = farm.getBuildingAt(tilePos);
-            
+
             // If there is no building at the tile, check if the tile intersects the edge of the main farmhouse.
-            if (building == null) return IntersectsRectEdge(farm.GetHouseRect(), tilePos);
+            building ??= farm.GetMainFarmHouse();
             
             // Check if the tile intersects the edge of the building.
             var buildingRect = new Rectangle(

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 ﻿{
   "Name":              "PlacementPlus",
   "Author":            "2Retr0",
-  "Version":           "1.2.0",
+  "Version":           "2.0.0-unofficial",
   "Description":       "Vastly broadens where objects and buildings can be placed!",
   "UniqueID":          "2Retr0.PlacementPlus",
   "EntryDll":          "PlacementPlus.dll",
-  "MinimumApiVersion": "3.0.0",
+  "MinimumApiVersion": "4.0.0",
   "UpdateKeys":      [ "Nexus:8798", 
                        "GitHub:2Retr0/PlacementPlus" ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name":              "PlacementPlus",
   "Author":            "2Retr0",
-  "Version":           "2.0.0-unofficial",
+  "Version":           "2.0.1-unofficial",
   "Description":       "Vastly broadens where objects and buildings can be placed!",
   "UniqueID":          "2Retr0.PlacementPlus",
   "EntryDll":          "PlacementPlus.dll",


### PR DESCRIPTION
Adds support for 1.6.0, with a few other minor changes. In particular:

- Removes the chest swapping handling; this seems to be available in vanilla now, as a consequence of the BigChest upgrade behaviour.
- Moves a bunch of code to use the new `QualifiedItemId` instead of `ParentSheetIndex`.

I'm using a temporary version code just for my own game, but it should be changed to something else if this ever gets merged. Would probably also need a README update.